### PR TITLE
ci: update checkout action runtime

### DIFF
--- a/.github/workflows/csrd-ci-smoke.yml
+++ b/.github/workflows/csrd-ci-smoke.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run CSRD smoke gate
         shell: powershell


### PR DESCRIPTION
## Summary
- Update the CSRD smoke workflow from actions/checkout@v4 to actions/checkout@v6.
- This addresses the GitHub Actions Node.js 20 deprecation annotation seen on the post-merge main run.

## Validation
- git diff --check
- The PR CI smoke check will validate the workflow path on GitHub.