### PR TITLE
fix: freeze ScenarioPlan Entities.Initial to the first frame (latent CreationTime=0 trap)

### DIFF
--- a/+csrd/+factories/ScenarioFactory.m
+++ b/+csrd/+factories/ScenarioFactory.m
@@ -821,8 +821,22 @@ classdef ScenarioFactory < matlab.System
             plan.GeometryPolicy = struct( ...
                 'Evaluation', 'SegmentMidpoint', ...
                 'Source', 'ScenarioPlan');
-            plan.Entities = struct( ...
-                'Initial', localNormalizeInitialEntitiesAtZero(entities));
+            % Entities.Initial must capture the scenario's first-frame (t=0)
+            % state ONCE and then stay fixed. enrichScenarioPlan runs every
+            % frame on the mobility-advanced `entities` (stepImpl advances them
+            % via step(physicalEnvironmentSimulator, frameId) before this call),
+            % so rebuilding Initial each frame stamps a later frame's advanced
+            % positions with CreationTime=0 / Snapshots{1}.FrameId=1 -- a false
+            % "initial" snapshot. The live geometry path reads the frozen
+            % obj.ScenarioPlan (assigned once per scenario in @ChangShuo), not
+            % this currentScenarioPlan, so this is a latent inconsistency today;
+            % guarding it keeps the recorded Initial honest if a future consumer
+            % ever reads it. Carry the first-captured value forward.
+            if ~(isfield(plan, 'Entities') && isstruct(plan.Entities) && ...
+                    isfield(plan.Entities, 'Initial') && ~isempty(plan.Entities.Initial))
+                plan.Entities = struct( ...
+                    'Initial', localNormalizeInitialEntitiesAtZero(entities));
+            end
             plan.Receivers = rxConfigs;
             plan.Transmitters = txConfigs;
             plan.Communication = localScenarioPlanCommunication( ...


### PR DESCRIPTION
## Why

Found in the round-14 measured-GT hunt as a **latent code-hygiene trap** (zero current measured-GT impact, verified).

`ScenarioFactory.enrichScenarioPlan` runs **every frame** on the mobility-advanced entities (`stepImpl` advances them via `step(physicalEnvironmentSimulator, frameId)` before the call), then rebuilt `currentScenarioPlan.Entities.Initial = localNormalizeInitialEntitiesAtZero(entities)` each frame — stamping a later frame's advanced positions with `CreationTime=0` / `Snapshots{1}.FrameId=1`, a false "initial" snapshot that drifts further from t=0 each frame.

## Why it is not a live bug today

- The live geometry path (`localResolveSegmentMidpointGeometry` ← `processChannelPropagation`) reads the **frozen** `obj.ScenarioPlan` (assigned once per scenario in `@ChangShuo`, genuine t=0), not `currentScenarioPlan`.
- The mutated `currentScenarioPlan` is surfaced only as `globalLayout.ScenarioPlan`, which a repo-wide grep shows is **never read**.
- The annotation records `ScenarioPlan.Frame` / `DatasetAccounting`, **not** `Entities`.

So `GeometrySnapshot` / `Doppler` are unaffected.

## Fix

Capture `Entities.Initial` **once** (first frame) and carry it forward instead of overwriting with frame-advanced positions, keeping the recorded Initial honest if a future consumer ever reads `globalLayout.ScenarioPlan`.

## Verification

- `checkcode` clean on the changed file.
- 10 scenario-plan / factory / MIMO-determinism unit tests pass.
- End-to-end `simulation(1,1,'csrd2025/csrd2025.m')` runs clean; `GeometrySnapshot` / `DopplerShiftHz` come from the frozen plan and are unchanged by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)