### PR TITLE
fix: five residual physical/label defects in the signal chain

### DIFF
--- a/+csrd/+blocks/+physical/+channel/BaseChannel.m
+++ b/+csrd/+blocks/+physical/+channel/BaseChannel.m
@@ -88,6 +88,14 @@ classdef BaseChannel < matlab.System
             % validity domain of each model.
             distance_m = max(obj.Distance, 1);
 
+            % Recompute the wavelength from the CURRENT carrier frequency
+            % instead of the constructor-time obj.WaveLength. The channel
+            % factory assigns the real per-link CarrierFrequency AFTER the
+            % constructor runs, but obj.WaveLength was frozen at the 200 MHz
+            % default; fspl therefore used a stale frequency while the
+            % fogpl/gaspl/rainpl terms below already use the real
+            % obj.CarrierFrequency, making genPathLoss internally inconsistent.
+            obj.WaveLength = physconst('light') / obj.CarrierFrequency;
             freeSpacePL = fspl(distance_m, obj.WaveLength);
 
             T = 15; % Temperature in degree C

--- a/+csrd/+blocks/+physical/+modulate/+analog/+AM/VSBAM.m
+++ b/+csrd/+blocks/+physical/+modulate/+analog/+AM/VSBAM.m
@@ -166,21 +166,38 @@ classdef VSBAM < csrd.blocks.physical.modulate.analog.AM.DSBSCAM
             frequencyAxis = (-samplesPerFrame / 2:samplesPerFrame / 2 - 1)' * ...
                 (obj.SampleRate / samplesPerFrame);
 
-            % Generate vestigial filter response across frequency axis
-            obj.vestigialFilterResponse = arrayfun(@(freq)obj.vestigialFilter(freq, 30e3/2), frequencyAxis);
+            % Vestigial filter passband edge follows the ACTUAL message
+            % occupied bandwidth (and therefore the configured SampleRate),
+            % instead of a hard-coded 15 kHz audio assumption. At a high RF
+            % SampleRate, or for any message whose content extends beyond
+            % 15 kHz, the old fixed edge zeroed the vestigial shaping for the
+            % out-of-band portion, collapsing VSB into DSB. msgBwHz is the
+            % two-sided occupied bandwidth, so msgBwHz/2 is the upper content
+            % edge passed to the vestigial filter.
+            msgBwHz = csrd.support.modulation.occupiedBandwidthHz( ...
+                messageSignal, obj.SampleRate);
+            obj.vestigialFilterResponse = arrayfun( ...
+                @(freq)obj.vestigialFilter(freq, msgBwHz / 2), frequencyAxis);
 
             % Transform input signal to frequency domain
             messageSpectrum = fftshift(fft(messageSignal));
 
-            % Apply vestigial filtering based on sideband mode configuration
+            % Apply vestigial filtering based on sideband mode configuration.
+            % The SIGN of the quadrature term selects the retained sideband:
+            % (response - flipud(response)) yields the analytic (upper) signal
+            % m + j*Hilbert(m), matching SSBAM's convention and the positive
+            % band reported below. The previous code had the two signs swapped,
+            % so 'upper' actually realized the lower sideband (and vice versa),
+            % i.e. the modulation label / Design band disagreed with the real
+            % spectrum.
             if strcmp(obj.ModulatorConfig.mode, 'upper')
                 % Upper sideband mode: keep upper sideband, partially filter lower
-                imaginaryComponent = messageSpectrum .* (flipud(obj.vestigialFilterResponse) - obj.vestigialFilterResponse);
-                bandWidth = [-obj.ModulatorConfig.cutoff, csrd.support.modulation.occupiedBandwidthHz(messageSignal, obj.SampleRate)];
+                imaginaryComponent = messageSpectrum .* (obj.vestigialFilterResponse - flipud(obj.vestigialFilterResponse));
+                bandWidth = [-obj.ModulatorConfig.cutoff, msgBwHz];
             else
                 % Lower sideband mode: keep lower sideband, partially filter upper
-                imaginaryComponent = messageSpectrum .* (obj.vestigialFilterResponse - flipud(obj.vestigialFilterResponse));
-                bandWidth = [-csrd.support.modulation.occupiedBandwidthHz(messageSignal, obj.SampleRate), obj.ModulatorConfig.cutoff];
+                imaginaryComponent = messageSpectrum .* (flipud(obj.vestigialFilterResponse) - obj.vestigialFilterResponse);
+                bandWidth = [-msgBwHz, obj.ModulatorConfig.cutoff];
             end
 
             % Convert filtered spectrum back to time domain

--- a/+csrd/+blocks/+physical/+rxRadioFront/RRFSimulator.m
+++ b/+csrd/+blocks/+physical/+rxRadioFront/RRFSimulator.m
@@ -338,12 +338,28 @@ classdef RRFSimulator < matlab.System
 
             xIq = obj.IQImbalance(xAwgn);
 
-            % Receiver DC offset (LO self-mixing / converter bias) leaks a small
-            % DC term into the baseband, matching the TX-side convention
-            % (DCOffset is a dBc level -> additive amplitude). Previously the RX
-            % DCOffset was recorded as a realized impairment in the annotation but
-            % never actually applied, so the annotated impairment was a phantom.
-            xIq = xIq + 10 ^ (obj.DCOffset / 20);
+            % Power gain of the IQ-imbalance stage (signal+noise), measured
+            % before the DC term is injected. Used to (a) refer the ADC
+            % quantization noise (which is sized at this post-IQ scale) back to
+            % the receiver-input scale, and (b) reference the DC offset to the
+            % received level.
+            postIqPower = mean(abs(double(xIq(:))) .^ 2);
+            awgnPower = mean(abs(double(xAwgn(:))) .^ 2);
+            if awgnPower > 0
+                iqPowerGain = postIqPower / awgnPower;
+            else
+                iqPowerGain = 1;
+            end
+
+            % Receiver DC offset (LO self-mixing / converter bias) leaks a DC
+            % term into the baseband. DCOffset is a dBc level, so the DC
+            % amplitude is referenced to the received RMS (sqrt of the post-IQ
+            % power) instead of being applied as a fixed absolute amplitude.
+            % With a fixed absolute amplitude the realized DC-to-signal ratio
+            % drifted with the received power (which varies across the SNR
+            % sweep and the ADC range) and no longer matched the annotated dBc
+            % value. A zero-power frame leaves the DC term at zero.
+            xIq = xIq + sqrt(postIqPower) * 10 ^ (obj.DCOffset / 20);
 
             % ADC quantization noise. A real N-bit converter imposes a
             % quantization noise floor that caps the realizable SNR at
@@ -369,10 +385,14 @@ classdef RRFSimulator < matlab.System
                     noiseStd = sqrt(quantNoisePower / 2);
                     xAdc = xIq + noiseStd * (randn(rs, size(xIq)) + 1i * randn(rs, size(xIq)));
                     % Refer the quantization noise to the receiver-input scale
-                    % (divide out the LNA power gain; IQ-imbalance power gain ~= 1)
                     % so it sums with the channel and thermal noise on the scale
-                    % the measured SNR GT uses.
-                    obj.RealizedAdcQuantizationNoiseInputReferredW = quantNoisePower / lnaPowerGain;
+                    % the measured SNR GT uses. The noise is sized at the
+                    % post-IQ scale, so divide out BOTH the LNA power gain and
+                    % the IQ-imbalance power gain (the latter was previously
+                    % approximated as 1, biasing the ADC-noise GT by the IQ
+                    % imbalance in the ADC-limited regime).
+                    obj.RealizedAdcQuantizationNoiseInputReferredW = ...
+                        quantNoisePower / (lnaPowerGain * iqPowerGain);
                 end
             end
 

--- a/tests/unit/BaseChannelDistanceTest.m
+++ b/tests/unit/BaseChannelDistanceTest.m
@@ -93,6 +93,34 @@ classdef BaseChannelDistanceTest < matlab.unittest.TestCase
                 'Path loss at 10 km must greatly exceed the 1 m value (attenuation tracks distance).');
         end
 
+        function freeSpacePathLossTracksCarrierSetAfterConstruction(testCase)
+            % Regression for the stale-wavelength bug: BaseChannel.WaveLength
+            % was computed once in the constructor from the default 200 MHz
+            % CarrierFrequency. The channel factory assigns the REAL carrier
+            % AFTER construction, so fspl used a 200 MHz wavelength while the
+            % fogpl/gaspl/rainpl terms used the real carrier (internally
+            % inconsistent path loss). genPathLoss must recompute the
+            % wavelength from the current CarrierFrequency.
+            distance_m = 1000;
+            ch = csrd.blocks.physical.channel.MIMO( ...
+                'FadingDistribution', 'Rayleigh', 'PathDelays', 0, ...
+                'AveragePathGains', 0, 'MaximumDopplerShift', 1, ...
+                'SampleRate', 1e6);
+            % CarrierFrequency stays at the 200 MHz default through
+            % construction, then the real carrier is assigned afterwards.
+            ch.Distance = distance_m;
+            ch.CarrierFrequency = 5.8e9;
+            in = struct('Signal', complex(ones(4096, 1)), ...
+                'SampleRate', 1e6, 'StartTime', 0);
+            ch.step(in);
+            expected = fspl(distance_m, physconst('light') / 5.8e9);
+            testCase.verifyLessThan(abs(ch.PathLoss - expected), 1, ...
+                'FSPL must track the carrier assigned after construction.');
+            stale = fspl(distance_m, physconst('light') / 200e6);
+            testCase.verifyGreaterThan(abs(ch.PathLoss - stale), 20, ...
+                'FSPL must not use the stale 200 MHz constructor wavelength.');
+        end
+
         function antennaModeIsSetCorrectly(testCase)
             ch = csrd.blocks.physical.channel.BaseChannel( ...
                 'NumTransmitAntennas', 2, 'NumReceiveAntennas', 4);

--- a/tests/unit/RRFSimulatorTest.m
+++ b/tests/unit/RRFSimulatorTest.m
@@ -147,6 +147,32 @@ classdef RRFSimulatorTest < matlab.unittest.TestCase
             release(simCoarse);
         end
 
+        function dcOffsetIsRelativeToReceivedLevel(testCase)
+            % Regression: DCOffset is a dBc level, so the realized DC spur must
+            % scale with the received RMS. The previous code added a fixed
+            % absolute amplitude 10^(DCOffset/20), so the realized DC-to-signal
+            % ratio drifted with the received power (which varies across the
+            % SNR sweep) and no longer matched the annotated dBc value. Drive
+            % the chain at two received levels and check the realized DC stays
+            % at the same dBc relative to the received level.
+            dcDb = -10;
+            rng(10);
+            base = complex(randn(8192, 1), randn(8192, 1));
+            base = base / sqrt(mean(abs(base) .^ 2)); % unit power
+            for scale = [1, 4]
+                sim = RRFSimulatorTest.makeSimulator(0);
+                sim.DCOffset = dcDb;
+                out = step(sim, scale * base);
+                dcAmplitude = abs(mean(out));
+                receivedRms = sqrt(mean(abs(out - mean(out)) .^ 2));
+                realizedDbc = 20 * log10(dcAmplitude / receivedRms);
+                testCase.verifyEqual(realizedDbc, dcDb, 'AbsTol', 1, ...
+                    sprintf(['Realized DC must stay at %g dBc relative to the ', ...
+                        'received level (received scale = %g).'], dcDb, scale));
+                release(sim);
+            end
+        end
+
     end
 
     methods (Static, Access = private)

--- a/tests/unit/VSBAMSidebandTest.m
+++ b/tests/unit/VSBAMSidebandTest.m
@@ -1,0 +1,81 @@
+classdef VSBAMSidebandTest < matlab.unittest.TestCase
+    % VSBAMSidebandTest - Guard the VSB-AM sideband realization.
+    %
+    %   Regression for two residual VSBAM defects found in the physical-
+    %   correctness audit:
+    %     * The vestigial-filter passband edge was hard-coded at 15 kHz,
+    %       ignoring the SampleRate / actual message bandwidth, so message
+    %       content beyond 15 kHz lost its vestigial shaping and VSB collapsed
+    %       toward DSB.
+    %     * The 'upper'/'lower' quadrature sign was swapped, so 'upper'
+    %       actually realized the lower sideband - the modulation label and the
+    %       reported Design band disagreed with the realized spectrum (and with
+    %       SSBAM's convention).
+    %
+    %   The measured plane re-measures OBW/center from the realized signal, so
+    %   these never produced non-finite values; they corrupted the modulation
+    %   label / Design band rather than tripping any finiteness gate.
+
+    methods (Test)
+
+        function upperKeepsPositiveSidebandLowerKeepsNegative(testCase)
+            [ratioUpper, bwUpper] = localModulate('upper');
+            [ratioLower, bwLower] = localModulate('lower');
+            % 'upper' must place the dominant energy on positive frequencies
+            % (USB), matching SSBAM and the positive reported band.
+            testCase.verifyGreaterThan(ratioUpper, 3, ...
+                'VSBAM upper must retain the positive (upper) sideband.');
+            testCase.verifyLessThan(ratioLower, -3, ...
+                'VSBAM lower must retain the negative (lower) sideband.');
+            % The reported band sign must match the realized sideband side.
+            testCase.verifyGreaterThan(bwUpper(2), abs(bwUpper(1)), ...
+                'upper band must extend further on the positive side.');
+            testCase.verifyGreaterThan(abs(bwLower(1)), bwLower(2), ...
+                'lower band must extend further on the negative side.');
+        end
+
+        function passbandAdaptsBeyond15kHz(testCase)
+            % A wideband audio message with content extending past the old
+            % hard-coded 15 kHz edge (here up to 22 kHz, DC-spanning like real
+            % audio) must still be shaped into one sideband. With the fixed
+            % 15 kHz edge the 15-22 kHz content lost its vestigial shaping and
+            % drifted toward DSB; the SampleRate/bandwidth-aware passband keeps
+            % the whole message single-sideband.
+            tones = [4e3, 10e3, 16e3, 22e3];
+            ratio = localModulate('upper', 200e3, tones);
+            testCase.verifyGreaterThan(ratio, 3, ...
+                'Wideband (>15 kHz) audio content must still be single-sideband shaped.');
+        end
+
+    end
+
+end
+
+function [ratioDb, bw] = localModulate(mode, Fs, toneHz)
+    if nargin < 2 || isempty(Fs)
+        Fs = 200e3;
+    end
+    if nargin < 3
+        toneHz = [];
+    end
+    N = 4096;
+    t = (0:N - 1)' / Fs;
+    if isempty(toneHz)
+        m = sin(2 * pi * 3e3 * t) + 0.7 * sin(2 * pi * 9e3 * t);
+    else
+        m = zeros(N, 1);
+        for f0 = toneHz(:)'
+            m = m + sin(2 * pi * f0 * t);
+        end
+    end
+    modulator = csrd.blocks.physical.modulate.analog.AM.VSBAM();
+    modulator.SampleRate = Fs;
+    modulator.ModulatorConfig.mode = mode;
+    modulator.ModulatorConfig.cutoff = 300;
+    handle = modulator.genModulatorHandle();
+    [sig, bw] = handle(m);
+    spec = fftshift(fft(sig));
+    posPower = sum(abs(spec(N / 2 + 2:end)) .^ 2);
+    negPower = sum(abs(spec(1:N / 2)) .^ 2);
+    ratioDb = 10 * log10(posPower / max(negPower, eps));
+end


### PR DESCRIPTION
## Context

A residual-bug audit targeting the **finite-but-physically-wrong** class — defects the existing finiteness/shape/NaN stress gates structurally cannot catch (the same class as the historical metres-as-degrees geometry bug) — swept 7 pipeline surfaces. It surfaced 8 candidates. Because the adversarial multi-agent verification pass was cut short, each candidate was verified by code reading: **5 confirmed real, 3 dismissed.**

`Truth.Measured` re-measures OBW/center/SNR from the realized signal, so none of these produced non-finite values; they corrupted **modulation labels, Design-plane bands, or impairment realization** rather than tripping a gate.

## Fixes (5)

| Area | Defect | Fix |
| --- | --- | --- |
| `VSBAM.m` | Vestigial passband hard-coded at 15 kHz → audio content >15 kHz lost shaping, VSB→DSB | Passband edge follows measured message bandwidth (`msgBwHz/2`) |
| `VSBAM.m` | `upper`/`lower` quadrature sign swapped → label/Design band disagreed with realized sideband | Signs swapped: `upper`→USB(+), `lower`→LSB(−), matching SSBAM |
| `BaseChannel.m` | `WaveLength` frozen at the 200 MHz constructor default; factory sets the real carrier afterward → `fspl` used a stale frequency while `fogpl/gaspl/rainpl` used the real one | `genPathLoss` recomputes wavelength from the current `CarrierFrequency` |
| `RRFSimulator.m` | RX DC offset added as fixed absolute amplitude although `DCOffset` is dBc → realized DC-to-signal ratio drifted with received power | Referenced to the received RMS (true dBc) |
| `RRFSimulator.m` | ADC quant noise sized post-IQ but input-referred by LNA gain only | Also divides out the IQ-imbalance power gain |

## Dismissed (3, with reason)

- **Thermal-noise GT measured pre-IQ** — the input-referred value is invariant to the IQ gain (it cancels), so the GT is correct.
- **TimeOccupancy single-window** — the envelope window is 100 µs (`min(1e-4, total)`), not whole-buffer; intra-burst gating coarser than 100 µs is captured.
- **TX DC offset** — set on the unit-power baseband and preserved through the later power scaling (Step 7 after Step 2), so it is correctly dBc.

## Out of scope (owner decision / follow-up)

- **Narrowband OBW resolution floor** — left as-is: a real SDR cannot resolve sub-FFT-bin signals, so the floored OBW is the *honest* receiver measurement, not a defect. Forcing the true emitter bandwidth would fake a resolution the receiver doesn't have.
- **38 coverage gaps** (untested dimension combinations: Doppler×fading, multi-frame×mobility, OSM-raytracing×measured-truth-gate, …) — proposed as a follow-up sweep + plausibility-band effort.

## Verification

3 new guard tests (`VSBAMSidebandTest`, FSPL-carrier-after-construction, DC-offset-relative). **43/43** affected unit tests pass; `checkcode` clean. No production config behavior changes for the controlled-SNR `csrd2025` path (the wavelength fix only affects distance-based-SNR mode, which `csrd2025` disables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)