### PR TITLE
fix: parallel workers share one session dir + harden multi_simulation launchers

### DIFF
--- a/+csrd/+runtime/+logger/GlobalLogManager.m
+++ b/+csrd/+runtime/+logger/GlobalLogManager.m
@@ -91,9 +91,24 @@ classdef GlobalLogManager < handle
                     'runs', 'global_logs');
             end
 
-            % Create timestamped session directory
-            currentTime = datetime('now', 'Format', 'yyyyMMdd_HHmmss');
-            sessionDirectory = fullfile(outputDirectory, sprintf('session_%s', currentTime));
+            % Per-process timestamp. Kept unique per process because it also
+            % names the logger instance below (concurrent workers must not share
+            % a logger name / log file).
+            currentTime = char(datetime('now', 'Format', 'yyyyMMdd_HHmmss'));
+
+            % Session directory name. Parallel launchers
+            % (tools/multi_simulation.*) export CSRD_SESSION_ID so every worker
+            % process writes into ONE shared session directory, instead of each
+            % process stamping its own second-resolution timestamp -- which
+            % scattered a single parallel run across N separate session_*
+            % folders. Falls back to the per-process timestamp when unset
+            % (single-process runs are unchanged). The value is sanitised to a
+            % path-safe token so it can only name a session folder.
+            sessionId = regexprep(getenv('CSRD_SESSION_ID'), '[^\w\-]', '');
+            if isempty(sessionId)
+                sessionId = currentTime;
+            end
+            sessionDirectory = fullfile(outputDirectory, sprintf('session_%s', sessionId));
             manager.logDirectory = fullfile(sessionDirectory, 'logs');
 
             % Create directory if it doesn't exist

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Shell scripts must stay LF (a CRLF shebang breaks the interpreter on Unix);
+# Windows batch files must stay CRLF.
+*.sh text eol=lf
+*.bat text eol=crlf

--- a/tests/unit/GlobalLogManagerSessionIdTest.m
+++ b/tests/unit/GlobalLogManagerSessionIdTest.m
@@ -1,0 +1,72 @@
+classdef GlobalLogManagerSessionIdTest < matlab.unittest.TestCase
+    % GlobalLogManagerSessionIdTest - guard the shared-session mechanism.
+    %
+    %   Parallel workers (tools/multi_simulation.*) must be able to write into
+    %   ONE session directory via the CSRD_SESSION_ID environment variable,
+    %   instead of each process stamping its own second-resolution timestamp
+    %   (which scattered a single parallel run across N session_* folders).
+
+    properties
+        OutRoot
+        PrevSessionId
+    end
+
+    methods (TestMethodSetup)
+        function setup(testCase)
+            testCase.PrevSessionId = getenv('CSRD_SESSION_ID');
+            testCase.OutRoot = tempname;
+            csrd.runtime.logger.GlobalLogManager.reset();
+        end
+    end
+
+    methods (TestMethodTeardown)
+        function teardown(testCase)
+            csrd.runtime.logger.GlobalLogManager.reset();
+            setenv('CSRD_SESSION_ID', testCase.PrevSessionId);
+            if exist(testCase.OutRoot, 'dir')
+                rmdir(testCase.OutRoot, 's');
+            end
+        end
+    end
+
+    methods (Test)
+
+        function honorsSharedSessionId(testCase)
+            setenv('CSRD_SESSION_ID', 'shared_run_1234');
+            csrd.runtime.logger.GlobalLogManager.reset();
+            csrd.runtime.logger.GlobalLogManager.initialize( ...
+                localCfg(), testCase.OutRoot);
+            logDir = csrd.runtime.logger.GlobalLogManager.getLogDirectory();
+            testCase.verifyTrue(contains(logDir, 'session_shared_run_1234'), ...
+                sprintf('logDir "%s" must use the shared CSRD_SESSION_ID.', logDir));
+        end
+
+        function sanitizesUnsafeSessionId(testCase)
+            setenv('CSRD_SESSION_ID', '../../evil id!!');
+            csrd.runtime.logger.GlobalLogManager.reset();
+            csrd.runtime.logger.GlobalLogManager.initialize( ...
+                localCfg(), testCase.OutRoot);
+            logDir = csrd.runtime.logger.GlobalLogManager.getLogDirectory();
+            testCase.verifyFalse(contains(logDir, '..'), ...
+                'A session id must never introduce a path-traversal component.');
+            testCase.verifyTrue(contains(logDir, 'session_evilid'), ...
+                sprintf('Unsafe chars must be stripped; got "%s".', logDir));
+        end
+
+        function fallsBackToTimestampWhenUnset(testCase)
+            setenv('CSRD_SESSION_ID', '');
+            csrd.runtime.logger.GlobalLogManager.reset();
+            csrd.runtime.logger.GlobalLogManager.initialize( ...
+                localCfg(), testCase.OutRoot);
+            logDir = csrd.runtime.logger.GlobalLogManager.getLogDirectory();
+            testCase.verifyNotEmpty(regexp(logDir, 'session_\d{8}_\d{6}', 'once'), ...
+                sprintf('Unset id must fall back to a timestamp session; got "%s".', logDir));
+        end
+
+    end
+
+end
+
+function cfg = localCfg()
+cfg = struct('Level', 'ERROR', 'SaveToFile', false, 'DisplayInConsole', false);
+end

--- a/tools/multi_simulation.bat
+++ b/tools/multi_simulation.bat
@@ -1,76 +1,39 @@
 @echo off
 setlocal enabledelayedexpansion
 
-:: Store the script's directory path
-set "SCRIPTDIR=%~dp0"
+:: Parallel multi-worker CSRD data generation.
+::
+:: Every worker shares ONE session directory via CSRD_SESSION_ID, so a parallel
+:: run fills a single data\<Dataset>\session_<ID>\ tree instead of scattering
+:: scenarios across one session_* folder per worker. Launch and wait are handled
+:: by PowerShell (reliable process IDs) rather than staggered starts + wmic.
 
-:: Create log directory if it doesn't exist
+set "SCRIPTDIR=%~dp0"
 if not exist "%SCRIPTDIR%logs" mkdir "%SCRIPTDIR%logs"
 
-:: Get number of workers from user input
+:: Number of workers (must be a positive integer).
 set /p numw="Enter number of workers: "
-
-:: Log start time
-echo Simulation started at %date% %time% > "%SCRIPTDIR%logs\simulation.log"
-
-:: Initialize arrays for PIDs and start times
-for /l %%i in (1,1,%numw%) do (
-    set "pid_%%i="
-    set "start_time_%%i=%time%"
+echo(!numw!| findstr /r "^[1-9][0-9]*$" >nul
+if errorlevel 1 (
+    echo Error: number of workers must be a positive integer.
+    exit /b 1
 )
 
-:: Run all MATLAB processes simultaneously
-for /l %%i in (1,1,%numw%) do (
-    :: Start MATLAB process for this worker
-    echo Starting worker %%i of %numw% >> "%SCRIPTDIR%logs\simulation.log"
-    
-    :: Start MATLAB and get its PID
-    start "Worker %%i" /D "%SCRIPTDIR%" matlab -nodesktop -nosplash -r "cd('%SCRIPTDIR%'); clc; clear; close all; simulation(%%i,%numw%);exit;"
-    
-    :: Wait briefly for the process to start
-    timeout /t 15 /nobreak > nul
-    
-    :: Get the PID of the newly started MATLAB process
-    for /f "skip=1 delims=" %%p in ('wmic process where "name='matlab.exe'" get ProcessId^,CommandLine') do (
-        echo %%p | findstr /i "simulation(%%i,%numw%)" >nul
-        if not errorlevel 1 (
-            for %%m in (%%p) do set "last=%%m"
-            set "pid_%%i=!last!"    
-            echo Launch A Matlab Worker with PID !pid_%%i!
-        )
-    )
-)
+:: One shared session id for every worker; exported so each MATLAB process
+:: inherits it and writes into the same session directory.
+for /f %%t in ('powershell -NoProfile -Command "Get-Date -Format yyyyMMdd_HHmmss"') do set "CSRD_SESSION_ID=%%t"
+set "CSRD_DIR=%SCRIPTDIR%"
+set "CSRD_NUMW=!numw!"
+set "LOGFILE=%SCRIPTDIR%logs\simulation_!CSRD_SESSION_ID!.log"
 
-:: Monitor MATLAB processes
-:wait
-timeout /t 1 /nobreak > nul
-set "running=0"
+echo Simulation started at %date% %time% ^| session !CSRD_SESSION_ID! ^| !numw! workers > "!LOGFILE!"
+echo Launching !numw! workers into shared session !CSRD_SESSION_ID! ...
 
-:: Check each worker's process
-for /l %%k   in (1,1,%numw%) do (
-    if defined pid_%%k (
-        :: Check if process still exists
-        wmic process where ProcessId^=!pid_%%k! get ProcessId 2>nul | find "!pid_%%k!" >nul
+:: Launch all workers in parallel and wait for every one to exit. The MATLAB -r
+:: string is built with single quotes only, so no inner double quotes fight the
+:: batch command wrapper.
+powershell -NoProfile -Command "$dir=$env:CSRD_DIR; $n=[int]$env:CSRD_NUMW; $procs=1..$n | ForEach-Object { Start-Process -FilePath 'matlab' -WorkingDirectory $dir -PassThru -ArgumentList @('-nodesktop','-nosplash','-r',('cd(''' + $dir + '''); clc; clear; close all; simulation(' + $_ + ', ' + $n + '); exit;')) }; Write-Host ('Launched workers: ' + ($procs.Id -join ', ')); $procs | Wait-Process; Write-Host 'All workers completed.'"
 
-        if not errorlevel 1 (
-            set "running=1"
-        ) else (
-            :: Process has ended, record completion time
-            if defined pid_%%k (
-                set "end_time=%time%"
-                echo Worker %%k ^(PID: !pid_%%k!^) completed at !end_time! >> "%SCRIPTDIR%logs\simulation.log"
-                echo Duration for Worker %%k: >> "%SCRIPTDIR%logs\simulation.log"
-                echo   Start: !start_time_%%k! >> "%SCRIPTDIR%logs\simulation.log"
-                echo   End  : !end_time! >> "%SCRIPTDIR%logs\simulation.log"
-                echo Matlab Worker with PID !pid_%%k! Completed
-                set "pid_%%k="
-            )
-        )
-    )
-)
-if !running!==1 goto wait
-
-:: Log completion time
-echo Simulation completed at %date% %time% >> "%SCRIPTDIR%logs\simulation.log"
-echo All workers completed. Check logs\simulation.log for details.
+echo Simulation completed at %date% %time% >> "!LOGFILE!"
+echo All workers completed. Session: !CSRD_SESSION_ID!. See "!LOGFILE!".
 pause

--- a/tools/multi_simulation.sh
+++ b/tools/multi_simulation.sh
@@ -1,71 +1,53 @@
-#! /bin/bash
+#!/bin/bash
+#
+# Parallel multi-worker CSRD data generation.
+#
+# Every worker shares ONE session directory via CSRD_SESSION_ID, so a parallel
+# run fills a single data/<Dataset>/session_<ID>/ tree instead of scattering
+# scenarios across one session_* folder per worker.
 
-# Store the script's directory path
+set -u
+
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-# Create log directory if it doesn't exist
 mkdir -p "$SCRIPTDIR/logs"
 
-# Get number of workers from user input
+# Number of workers (must be a positive integer).
 read -p "Enter number of workers: " numw
+if ! [[ "$numw" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: number of workers must be a positive integer (got '$numw')." >&2
+    exit 1
+fi
 
-# Log start time
-echo "Simulation started at $(date)" > "$SCRIPTDIR/logs/simulation.log"
+# One shared session id for every worker; exported so each MATLAB process
+# inherits it and writes into the same session directory.
+export CSRD_SESSION_ID="$(date +%Y%m%d_%H%M%S)"
+LOGFILE="$SCRIPTDIR/logs/simulation_${CSRD_SESSION_ID}.log"
 
-# Initialize arrays for PIDs and start times
+echo "Simulation started at $(date) | session ${CSRD_SESSION_ID} | ${numw} workers" | tee "$LOGFILE"
+
+# Launch all workers concurrently.
 declare -A pids
-declare -A start_times
-
-# Run all MATLAB processes simultaneously
-for ((i=1; i<=$numw; i++))
-do
-    # Record start time for this worker
-    start_times[$i]=$(date +%H:%M:%S)
-    echo "Starting worker $i of $numw" >> "$SCRIPTDIR/logs/simulation.log"
-    
-    # Start MATLAB process and capture its PID
-    {
-        scriptname=$(printf 'simulation(%d, %d)' "$i" "$numw")
-        echo "run script: $scriptname"
-        matlab -nodesktop -nosplash -r "cd('$SCRIPTDIR'); clc; clear; close all; $scriptname; exit;"
-    } &
-    
-    # Store the PID
+for ((i=1; i<=numw; i++)); do
+    matlab -nodesktop -nosplash -r "cd('$SCRIPTDIR'); clc; clear; close all; simulation($i, $numw); exit;" &
     pids[$i]=$!
-    echo "Launch A Matlab Worker with PID ${pids[$i]}"
-    echo "Worker $i started with PID ${pids[$i]} at ${start_times[$i]}" >> "$SCRIPTDIR/logs/simulation.log"
+    echo "Launched worker $i of $numw (PID ${pids[$i]})" | tee -a "$LOGFILE"
 done
 
-wait
-
-# Monitor all processes
-while true; do
-    running=0
-    for ((i=1; i<=$numw; i++))
-    do
-        if kill -0 ${pids[$i]} 2>/dev/null; then
-            running=1
-        else
-            # Process has ended, record completion time
-            if [ ! -z "${pids[$i]}" ]; then
-                end_time=$(date +%H:%M:%S)
-                echo "Worker $i (PID: ${pids[$i]}) completed at $end_time" >> "$SCRIPTDIR/logs/simulation.log"
-                echo "Duration for Worker $i:" >> "$SCRIPTDIR/logs/simulation.log"
-                echo "  Start: ${start_times[$i]}" >> "$SCRIPTDIR/logs/simulation.log"
-                echo "  End  : $end_time" >> "$SCRIPTDIR/logs/simulation.log"
-                echo "Matlab Worker with PID ${pids[$i]} Completed"
-                pids[$i]=""
-            fi
-        fi
-    done
-    
-    if [ $running -eq 0 ]; then
-        break
+# Wait for each worker and log completion. `wait <pid>` blocks on that worker
+# and reaps it, so there is no busy-poll and no defunct-process false "running".
+rc=0
+for ((i=1; i<=numw; i++)); do
+    if wait "${pids[$i]}"; then
+        echo "Worker $i (PID ${pids[$i]}) completed at $(date +%H:%M:%S)" | tee -a "$LOGFILE"
+    else
+        status=$?
+        rc=1
+        echo "Worker $i (PID ${pids[$i]}) FAILED (exit $status) at $(date +%H:%M:%S)" | tee -a "$LOGFILE"
     fi
-    
-    sleep 10
 done
 
-# Log completion time
-echo "Simulation completed at $(date)" >> "$SCRIPTDIR/logs/simulation.log"
-echo "All workers completed. Check logs/simulation.log for details."
+echo "Simulation completed at $(date) | session ${CSRD_SESSION_ID}" | tee -a "$LOGFILE"
+if [ "$rc" -ne 0 ]; then
+    echo "One or more workers failed. See $LOGFILE." >&2
+fi
+exit $rc


### PR DESCRIPTION
## Context

`tools/multi_simulation.bat` / `.sh` launch multiple MATLAB workers for parallel data generation. The round-robin scenario partition (`simulation(i, N)`) was correct — no data corruption — but there were three real problems.

## Problems fixed

### 1. Fragmented output (both launchers) — the real pain point
Each worker is a **separate MATLAB process** that stamped its **own** second-resolution `session_YYYYMMDD_HHMMSS` directory (`GlobalLogManager` → `SimulationRunner.actualOutputDirectory`). So a single parallel run scattered `scenario_000001` (worker 1), `scenario_000002` (worker 2), … across **N different `session_*` folders** — the `.bat`'s 15 s-per-worker stagger *guaranteed* it. You'd have to merge folders by hand.

**Fix:** `GlobalLogManager` now honours a **`CSRD_SESSION_ID`** env var (sanitised to a path-safe token) for the session directory, falling back to the per-process timestamp when unset. Both launchers generate **one** session id and export it, so every worker writes into a single `data/<Dataset>/session_<ID>/` tree. The logger *instance* keeps its own per-process timestamp, so concurrent workers don't collide on a log file. Single-process runs are unchanged.

### 2. `.sh`: dead monitoring loop
The `wait` before the monitor loop made it dead code — all "completed" logs dumped at the end, and `kill -0` on an un-reaped child could false-positive as running. Rewritten to launch all, then `wait <pid>` each (reaps + logs completion), with input validation.

### 3. `.bat`: staggered launches + fragile PID capture
`timeout /t 15` per worker (contradicting "simultaneous") and a `wmic` command-line substring match that could grab the wrong PID or report **premature completion**. Rewritten to launch + `Wait-Process` via PowerShell (reliable PIDs), with input validation.

Also pinned `*.sh eol=lf` / `*.bat eol=crlf` in `.gitattributes` (a CRLF shebang breaks on Unix).

## Verification

New `GlobalLogManagerSessionIdTest` (shared id honoured · unsafe id sanitised · unset → timestamp fallback). **20/20 logger unit tests pass** (the change first broke the reused `currentTime` used for the logger name — caught by the existing logger tests and fixed). `checkcode` clean. The PowerShell launch/`Wait-Process` pattern and the `.sh` syntax were validated, and the constructed MATLAB `-r` strings were confirmed correct; the full `.bat` was not run end-to-end (no cmd.exe in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)