### PR TITLE
docs: add Citation section (framework + related papers) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ branch, not on `main`.
 
 ## Citation
 
-If you use ChangShuoRadioData, please cite the framework:
+If you use ChangShuoRadioData, please cite both the framework and the CSRD2025
+dataset paper:
 
 ```bibtex
 @software{chang_shuo_2025_10667001,
@@ -195,17 +196,28 @@ If you use ChangShuoRadioData, please cite the framework:
 }
 ```
 
-### Related papers
+```bibtex
+@ARTICLE{11289512,
+  author={Chang, Shuo and Sun, Rui and He, Jiashuo and Huang, Sai and Yu, Kan and Feng, Zhiyong},
+  journal={IEEE Journal on Selected Areas in Communications}, 
+  title={CSRD2025: A Large-Scale Synthetic Radio Dataset for Spectrum Sensing in Wireless Communications}, 
+  year={2026},
+  volume={44},
+  number={},
+  pages={2378-2392},
+  keywords={Radio frequency;Wireless communication;Sensors;Annotations;Data acquisition;Synthetic data;Interference;Data models;Wireless sensor networks;Emulation;Synthetic radio dataset;spectrum sensing;large AI models},
+  doi={10.1109/JSAC.2025.3641910}}
+```
 
-- **JSAC-era version — outdated; do not start from it.** An earlier version of
-  this project accompanied the JSAC-era work and is preserved only at the
-  historical revision
-  [`a6d09a4b`](https://github.com/Singingkettle/ChangShuoRadioData/tree/a6d09a4b264894b76f852ce33bfd82adc7b270b5).
-  That version is **much older than the current framework — new users should
-  build on the latest `main`, not the JSAC-era code.**
-- **IEEE TWC paper — `twc/` folder only.** The paper below corresponds **only to
-  the [`twc/`](twc/) subfolder and is independent of the main framework**; cite
-  it only if you use that folder:
+> **The JSAC paper describes an earlier version** of this framework, preserved at
+> the historical revision
+> [`a6d09a4b`](https://github.com/Singingkettle/ChangShuoRadioData/tree/a6d09a4b264894b76f852ce33bfd82adc7b270b5).
+> New users should build on the **latest `main`**, not that revision.
+
+### Related work — `twc/` folder only
+
+The IEEE TWC paper below corresponds **only to the [`twc/`](twc/) subfolder and
+is independent of the main framework**; cite it only if you use that folder:
 
 ```bibtex
 @ARTICLE{10667001,

--- a/README.md
+++ b/README.md
@@ -179,5 +179,43 @@ preserved on the
 [`archive/history-2026-06-30`](https://github.com/Singingkettle/ChangShuoRadioData/tree/archive/history-2026-06-30)
 branch, not on `main`.
 
-If you need the older JSAC-era behavior, use the historical stable revision:
-[a6d09a4b264894b76f852ce33bfd82adc7b270b5](https://github.com/Singingkettle/ChangShuoRadioData/tree/a6d09a4b264894b76f852ce33bfd82adc7b270b5).
+## Citation
+
+If you use ChangShuoRadioData, please cite the framework:
+
+```bibtex
+@software{chang_shuo_2025_10667001,
+  author       = {Chang, Shuo},
+  title        = {ChangShuoRadioData: A Comprehensive MATLAB-based Radio Communication Simulation Framework},
+  month        = mar,
+  year         = 2025,
+  publisher    = {ChangShuoLab},
+  version      = {v1.0.0},
+  url          = {https://github.com/Singingkettle/ChangShuoRadioData}
+}
+```
+
+### Related papers
+
+- **JSAC-era version — outdated; do not start from it.** An earlier version of
+  this project accompanied the JSAC-era work and is preserved only at the
+  historical revision
+  [`a6d09a4b`](https://github.com/Singingkettle/ChangShuoRadioData/tree/a6d09a4b264894b76f852ce33bfd82adc7b270b5).
+  That version is **much older than the current framework — new users should
+  build on the latest `main`, not the JSAC-era code.**
+- **IEEE TWC paper — `twc/` folder only.** The paper below corresponds **only to
+  the [`twc/`](twc/) subfolder and is independent of the main framework**; cite
+  it only if you use that folder:
+
+```bibtex
+@ARTICLE{10667001,
+  author={Xing, Huijun and Zhang, Xuhui and Chang, Shuo and Ren, Jinke and Zhang, Zixun and Xu, Jie and Cui, Shuguang},
+  journal={IEEE Transactions on Wireless Communications}, 
+  title={Joint Signal Detection and Automatic Modulation Classification via Deep Learning}, 
+  year={2024},
+  volume={23},
+  number={11},
+  pages={17129-17142},
+  keywords={Feature extraction;Signal detection;Frequency modulation;Time-frequency analysis;Signal to noise ratio;Industries;Deep learning;Automatic modulation classification;dataset design;hierarchical classification head},
+  doi={10.1109/TWC.2024.3450972}}
+```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -176,5 +176,41 @@ runtests('tests/unit/MeasurementCompletenessHookTest.m')
 [`archive/history-2026-06-30`](https://github.com/Singingkettle/ChangShuoRadioData/tree/archive/history-2026-06-30)
 分支,不在 `main` 上。
 
-如果需要旧 JSAC 时代的行为，请查看历史稳定 revision：
-[a6d09a4b264894b76f852ce33bfd82adc7b270b5](https://github.com/Singingkettle/ChangShuoRadioData/tree/a6d09a4b264894b76f852ce33bfd82adc7b270b5)。
+## 引用
+
+如果你使用 ChangShuoRadioData,请引用本框架:
+
+```bibtex
+@software{chang_shuo_2025_10667001,
+  author       = {Chang, Shuo},
+  title        = {ChangShuoRadioData: A Comprehensive MATLAB-based Radio Communication Simulation Framework},
+  month        = mar,
+  year         = 2025,
+  publisher    = {ChangShuoLab},
+  version      = {v1.0.0},
+  url          = {https://github.com/Singingkettle/ChangShuoRadioData}
+}
+```
+
+### 相关论文
+
+- **JSAC 时代版本 —— 已过时,不要以它为起点。** 本项目的早期版本对应 JSAC 时代的
+  工作,仅保留在历史 revision
+  [`a6d09a4b`](https://github.com/Singingkettle/ChangShuoRadioData/tree/a6d09a4b264894b76f852ce33bfd82adc7b270b5)。
+  该版本**比当前框架旧很多——新用户请基于最新的 `main` 开发,不要使用 JSAC 时代的
+  代码。**
+- **IEEE TWC 论文 —— 仅对应 `twc/` 文件夹。** 下面这篇论文**只对应
+  [`twc/`](twc/) 子文件夹,与主框架相互独立**;仅当你使用该文件夹时才需要引用:
+
+```bibtex
+@ARTICLE{10667001,
+  author={Xing, Huijun and Zhang, Xuhui and Chang, Shuo and Ren, Jinke and Zhang, Zixun and Xu, Jie and Cui, Shuguang},
+  journal={IEEE Transactions on Wireless Communications}, 
+  title={Joint Signal Detection and Automatic Modulation Classification via Deep Learning}, 
+  year={2024},
+  volume={23},
+  number={11},
+  pages={17129-17142},
+  keywords={Feature extraction;Signal detection;Frequency modulation;Time-frequency analysis;Signal to noise ratio;Industries;Deep learning;Automatic modulation classification;dataset design;hierarchical classification head},
+  doi={10.1109/TWC.2024.3450972}}
+```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -178,7 +178,7 @@ runtests('tests/unit/MeasurementCompletenessHookTest.m')
 
 ## 引用
 
-如果你使用 ChangShuoRadioData,请引用本框架:
+如果你使用 ChangShuoRadioData,请同时引用本框架和 CSRD2025 数据集论文:
 
 ```bibtex
 @software{chang_shuo_2025_10667001,
@@ -192,15 +192,27 @@ runtests('tests/unit/MeasurementCompletenessHookTest.m')
 }
 ```
 
-### 相关论文
+```bibtex
+@ARTICLE{11289512,
+  author={Chang, Shuo and Sun, Rui and He, Jiashuo and Huang, Sai and Yu, Kan and Feng, Zhiyong},
+  journal={IEEE Journal on Selected Areas in Communications}, 
+  title={CSRD2025: A Large-Scale Synthetic Radio Dataset for Spectrum Sensing in Wireless Communications}, 
+  year={2026},
+  volume={44},
+  number={},
+  pages={2378-2392},
+  keywords={Radio frequency;Wireless communication;Sensors;Annotations;Data acquisition;Synthetic data;Interference;Data models;Wireless sensor networks;Emulation;Synthetic radio dataset;spectrum sensing;large AI models},
+  doi={10.1109/JSAC.2025.3641910}}
+```
 
-- **JSAC 时代版本 —— 已过时,不要以它为起点。** 本项目的早期版本对应 JSAC 时代的
-  工作,仅保留在历史 revision
-  [`a6d09a4b`](https://github.com/Singingkettle/ChangShuoRadioData/tree/a6d09a4b264894b76f852ce33bfd82adc7b270b5)。
-  该版本**比当前框架旧很多——新用户请基于最新的 `main` 开发,不要使用 JSAC 时代的
-  代码。**
-- **IEEE TWC 论文 —— 仅对应 `twc/` 文件夹。** 下面这篇论文**只对应
-  [`twc/`](twc/) 子文件夹,与主框架相互独立**;仅当你使用该文件夹时才需要引用:
+> **这篇 JSAC 论文描述的是本框架较早的版本**,该版本保留在历史 revision
+> [`a6d09a4b`](https://github.com/Singingkettle/ChangShuoRadioData/tree/a6d09a4b264894b76f852ce33bfd82adc7b270b5)。
+> 新用户请基于**最新的 `main`** 开发,而不是那个 revision。
+
+### 相关工作 —— 仅对应 `twc/` 文件夹
+
+下面这篇 IEEE TWC 论文**只对应 [`twc/`](twc/) 子文件夹,与主框架相互独立**;仅当你
+使用该文件夹时才需要引用:
 
 ```bibtex
 @ARTICLE{10667001,


### PR DESCRIPTION
Adds a **Citation** section to `README.md` and `README.zh-CN.md` (bilingual).

**Contents**
- **Framework citation** — the `@software` entry for ChangShuoRadioData (Chang, 2025).
- **JSAC-era version** — kept as a history-only link to revision [`a6d09a4b`](https://github.com/Singingkettle/ChangShuoRadioData/tree/a6d09a4b264894b76f852ce33bfd82adc7b270b5), with an explicit note that it is **much older than the current framework — new users should build on the latest `main`, not the JSAC-era code.**
- **IEEE TWC paper** (Xing et al., 2024) — clearly scoped: it corresponds **only to the [`twc/`](twc/) subfolder and is independent of the main framework**; cite only if you use that folder.

BibTeX entries are included verbatim as provided. The docs language-policy gate passes (both READMEs still cross-link; the Chinese version has the translated prose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)